### PR TITLE
Batch updates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,25 +72,12 @@ function parseBuffer(buffer) {
   return pixel;
 }
 
-async function updateImage(pixel) {
+async function updateImage(image, pixel) {
   let x = pixel.x;
   let y = pixel.y;
   let color = pixel.color;
-  let image;
-
-  try {
-    image = await Jimp.read('./public/image.jpg');
-    console.log("file found")
-  } catch {
-    console.log("file not found")
-    image = new Jimp(1000, 1000, 0x000000ff, (err, image) => {
-      if (err) throw err
-    });
-  }
 
   await image.setPixelColor(color, x, y);
-
-  image.write("./public/image.jpg");
 }
 
 async function main() {
@@ -108,6 +95,17 @@ async function main() {
     `You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`
   );
 
+  let image;
+  try {
+    image = await Jimp.read('./public/image.jpg');
+    console.log("file found")
+  } catch (e) {
+    console.log("file not found: ", e);
+    image = new Jimp(1000, 1000, 0x000000ff, (err, image) => {
+      if (err) throw err
+    });
+  }
+
   // Subscribe to the new headers on-chain. The callback is fired when new headers
   // are found, the call itself returns a promise with a subscription that can be
   // used to unsubscribe from the newHead subscription
@@ -121,10 +119,11 @@ async function main() {
           let pixel = parseBuffer(extrinsic.args[0]);
           console.log("Pixel: ", pixel);
           if (pixel) {
-            await updateImage(pixel);
+            await updateImage(image, pixel);
           }
         }
       }
+      await image.write("./public/image.jpg");
     });
   });
 }


### PR DESCRIPTION
This PR changes the way we update pixels in the canonical image. Before, we loaded and written the image each time we write pixels. This approach has some problems: first, it is super slow. If the blocks are saturated with transactions, it takes a lot of time to process such a block. Second and more importantly, we loaded/stored the image for each pixel. Since we are using JPG, this affects the image quality pretty significantly.

This PR makes sure that we load image once and flush updated image to disk every block. 